### PR TITLE
windows: test praat script indirectly by writing to temp file

### DIFF
--- a/praat-wrapper/windows/src/test/resources/org/m2ci/msp/praat/build.gradle
+++ b/praat-wrapper/windows/src/test/resources/org/m2ci/msp/praat/build.gradle
@@ -18,6 +18,9 @@ task canExtractPraat {
 task canRunPraat(type: Exec) {
     dependsOn praat
     commandLine praat.binary, 'script.praat'
+    doLast {
+        println file('output.txt').text
+    }
 }
 
 task testPraatVersion {

--- a/praat-wrapper/windows/src/test/resources/org/m2ci/msp/praat/script.praat
+++ b/praat-wrapper/windows/src/test/resources/org/m2ci/msp/praat/script.praat
@@ -1,3 +1,3 @@
 assert windows
 assert praatVersion\$ == "$praatVersion"
-echo 'praatVersion\$'
+praatVersion\$ > output.txt


### PR DESCRIPTION
workaround for #6